### PR TITLE
Check for TRs rather than repeat_scores

### DIFF
--- a/polyA/_runners.py
+++ b/polyA/_runners.py
@@ -357,7 +357,7 @@ def run_full(
     support_matrix.clear()
     consensus_matrix.clear()
 
-    if not repeat_scores:
+    if len(tandem_repeats) > 0:
         # give different TRs consensus positions that don't allow them to be stitched
         tr_consensus_pos = 1000000
         prev_tr_col = 0


### PR DESCRIPTION
When I fixed the remaining type errors I assumed that `repeat_scores == {}` was equivalent to the previous situation where we checked `repeat_scores is None` since I changed its default value to an empty dict. Unfortunately, `calculate_repeat_scores` can apparently return an empty dict, which caused problems down the line since some of the TR code didn't run when it should have.