### PR TITLE
Clean up both versions of fill_confidence_matrix

### DIFF
--- a/polyA/_runners.py
+++ b/polyA/_runners.py
@@ -288,9 +288,8 @@ def run_full(
             subfam_counts,
             alignment_subfamilies,
             active_cells,
-            active_cells,
-            repeat_scores,
             align_matrix,
+            repeat_scores,
         )
 
         # check if TR columns were added after last alignment

--- a/polyA/fill_confidence_matrix.py
+++ b/polyA/fill_confidence_matrix.py
@@ -1,36 +1,43 @@
-from typing import Dict, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
-from polyA.confidence_cm import confidence_cm
-from polyA.matrices import ConfidenceMatrix
-from polyA.performance import timeit
+from .confidence_cm import confidence_cm
+from .matrices import ConfidenceMatrix
+from .performance import timeit
 
 
 @timeit
 def fill_confidence_matrix(
-    columns: List[int],
+    columns: Iterable[int],
     subfam_counts: Dict[str, float],
     subfams: List[str],
     active_cells: Dict[int, List[int]],
     align_matrix: Dict[Tuple[int, int], float],
 ) -> ConfidenceMatrix:
     """
-    Fills confidence matrix from alignment matrix. Each column in the alignment matrix is a group of competing
-    annotations that are input into confidence_cm, the output confidence values are used to populate confidence_matrix.
+    Fills confidence matrix from alignment matrix. Each column in the alignment
+    matrix is a group of competing annotations that are input into
+    confidence_cm, the output confidence values are used to populate
+    confidence_matrix.
 
-    input:
-    everything needed for confidence_cm()
-    columns: array that holds all non empty columns in align matrix
-    subfam_counts: dictionary that maps subfam names to prior counts
-    subfams: array of subfam names from original input alignment
-    active_cells: maps col numbers to all active rows in that col
-    align_matrix: matrix with alignment scores - used to calculate confidence
+    Inputs:
 
-    output:
-    confidence_matrix: Hash implementation of sparse 2D matrix used in pre-DP calculations. Key is
-    tuple[int, int] that maps row, col with the value held in that cell of matrix. Rows are
-    subfamilies in the input alignment file, cols are nucleotide positions in the alignment.
-    Each cell in matrix is the confidence score calculated from all the alignment scores in a
-    column of the AlignHash
+    columns - non empty matrix column indices
+    subfam_counts - mapping of subfamily names to their prior counts
+    subfams - list of subfamily names taken from the original alignments
+    active_cells - map of column indices (from columns) into list of non-empty
+    rows for the given column
+    align_matrix - the alignment matrix from fill_align_matrix
+
+    Outputs:
+
+    confidence_matrix - hash implementation of sparse 2D matrix used in pre-DP
+    calculations. Key is tuple[int, int] that maps row, col with the value held
+    in that cell of matrix. Rows are subfamilies in the input alignment file,
+    cols are nucleotide positions in the alignment. Each cell in matrix is the
+    confidence score calculated from all the alignment scores in a column of the
+    alignment matrix.
+
+    TODO: Update test to reflect that real matrices have only skip state in first and last columns
 
     >>> align_mat = {(0, 0): 0, (0, 1): 100, (0, 2): 99, (1, 0): 100, (1, 1): 100, (1, 2): 100}
     >>> active = {0: [0, 1], 1: [0, 1], 2: [0, 1]}
@@ -53,9 +60,7 @@ def fill_confidence_matrix(
     """
     confidence_matrix: ConfidenceMatrix = {}
 
-    for i in range(len(columns)):
-
-        col_index: int = columns[i]
+    for col_index in columns:
         temp_region: List[float] = []
 
         for row_index in active_cells[col_index]:

--- a/polyA/fill_confidence_matrix_tr.py
+++ b/polyA/fill_confidence_matrix_tr.py
@@ -1,87 +1,48 @@
 from typing import Dict, List, Tuple
 
-from .confidence_cm import confidence_cm
+from .fill_confidence_matrix import fill_confidence_matrix
 from .performance import timeit
 
 
 @timeit
 def fill_confidence_matrix_tr(
     columns: List[int],
-    subfam_countss: Dict[str, float],
-    subfamss: List[str],
+    subfam_counts: Dict[str, float],
+    subfams: List[str],
     active_cells: Dict[int, List[int]],
-    active_cells_trailing: Dict[int, List[int]],
-    repeat_scores: Dict[int, float],
     align_matrix: Dict[Tuple[int, int], float],
+    repeat_scores: Dict[int, float],
 ) -> Dict[Tuple[int, int], float]:
     """
-    Fills confidence matrix from alignment matrix including TR scores. Each column in the alignment matrix is a group of competing
-    annotations that are input into ConfidenceCM.
-    The output confidence values are used to populate confidence_matrix.
+    Mostly identical to fill_confidence_matrix, but takes into account that some
+    columns in the alignment matrix may hold tandem repeats.
 
-    input:
-    everything needed for ConfidenceCM
-    columns: array that holds all non empty columns in align matrix
-    subfam_counts: dictionary that maps subfam names to prior counts
-    subfams: array of subfam names from original input alignment
-    active_cells: maps col numbers to all active rows in that col
-    active_cells_trailing: same as above but has trailing cells on ends of alignments
-    repeat_score: dict that maps col in target sequence to tandem repeat score
-    align_matrix: alignment matrix - used to calculate confidence
+    Inputs:
 
-    output:
-    confidence_matrix: Hash implementation of sparse 2D matrix used in pre-DP calculations. Key is
-    tuple[row, col] to value held in that cell of matrix.
+    Superset of the inputs to fill_confidence_matrix. Additions are listed
+    below.
+
+    repeat_scores - maps column indices to tandem repeat scores.
+
+    Outputs:
+
+    Same as `fill_confidence_matrix`.
     """
+    confidence_matrix = fill_confidence_matrix(
+        columns,
+        subfam_counts,
+        subfams,
+        active_cells,
+        align_matrix,
+    )
+    tr_confidence_matrix = fill_confidence_matrix(
+        repeat_scores.keys(),
+        subfam_counts,
+        subfams,
+        active_cells,
+        align_matrix,
+    )
 
-    confidence_matrix: Dict[Tuple[int, int], float] = {}
-
-    # calculates confidence for alignment only columns
-    # cols that feature a TR score will be replaced in next for loop
-    for i in range(len(columns)):
-        col_index: int = columns[i]
-        temp_region: List[float] = []
-
-        for row_index in active_cells_trailing[col_index]:
-            temp_region.append(align_matrix[row_index, col_index])
-
-        temp_confidence: List[float] = confidence_cm(
-            temp_region,
-            subfam_countss,
-            subfamss,
-            active_cells_trailing[col_index],
-            0,
-            False,
-        )
-
-        for row_index2 in range(len(active_cells_trailing[col_index])):
-            confidence_matrix[
-                active_cells_trailing[col_index][row_index2], col_index
-            ] = temp_confidence[row_index2]
-
-    # go through non empty TR columns
-    for tr_col in repeat_scores:
-        col_index = tr_col
-        temp_region = []
-
-        # last row in col is TR
-        # assumes TRs do not overlap in a column
-        for row_index in active_cells[col_index]:
-            temp_region.append(align_matrix[row_index, col_index])
-
-        temp_confidence = confidence_cm(
-            temp_region,
-            subfam_countss,
-            subfamss,
-            active_cells[col_index],
-            1,
-            False,
-        )
-
-        # will replace cols that had both TR and alignment scores
-        for row_index2 in range(len(active_cells[col_index])):
-            confidence_matrix[
-                active_cells[col_index][row_index2], col_index
-            ] = temp_confidence[row_index2]
+    confidence_matrix.update(tr_confidence_matrix)
 
     return confidence_matrix


### PR DESCRIPTION
We had a lot of duplicate logic in the two versions of `fill_confidence_matrix`, so now we share that logic and handle only the differences in the TR version of the function.