### PR TITLE
Add linting to makefile and CI

### DIFF
--- a/.github/workflows/polyA-ci.yml
+++ b/.github/workflows/polyA-ci.yml
@@ -33,6 +33,16 @@ jobs:
       - uses: actions/checkout@v1
       - run: make setup-dev check-format
 
+  check-lints:
+    runs-on: ubuntu-20.04
+    container:
+      image: traviswheelerlab/polya-build
+      volumes:
+        - ${{ github.workspace }}:/code
+    steps:
+      - uses: actions/checkout@v1
+      - run: make setup-dev check-lints
+
   check-types:
     runs-on: ubuntu-20.04
     container:

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ publish-conda-package:
 	@echo "NOT IMPLEMENTED"
 
 .PHONY: check
-check: check-fast check-slow check-format check-types
+check: check-format check-lints check-types check-fast check-slow
 
 .PHONY: check-fast
 check-fast:
@@ -59,6 +59,10 @@ check-fast:
 .PHONY: check-format
 check-format:
 	${FMT_CMD} --check ${FMT_OPTS} ${FMT_TARGETS}
+
+.PHONY: check-lints
+check-lints:
+	${RUN_CMD} pylint -E polyA/
 
 .PHONY: check-types
 check-types:

--- a/polyA/_runners.py
+++ b/polyA/_runners.py
@@ -3,7 +3,33 @@ from math import log
 from sys import stdout
 from typing import Dict, List, Optional, TextIO, Tuple
 
-from polyA import *
+from polyA import (
+    Alignment,
+    CHANGE_PROB,
+    SAME_PROB_LOG,
+    SKIP_ALIGN_SCORE,
+    SubMatrix,
+    SubMatrixCollection,
+    TandemRepeat,
+    calculate_repeat_scores,
+    collapse_matrices,
+    confidence_only,
+    edges,
+    extract_nodes,
+    fill_align_matrix,
+    fill_confidence_matrix,
+    fill_consensus_position_matrix,
+    fill_node_confidence,
+    fill_path_graph,
+    fill_probability_matrix,
+    fill_support_matrix,
+    get_path,
+    pad_sequences,
+    print_results,
+    print_results_chrom,
+    print_results_sequence,
+    print_results_soda,
+)
 
 
 def run_confidence(


### PR DESCRIPTION
We have a lot of code lints to address eventually, but for now we might as well run the linter in error-only mode to check for the most serious issues.