### PR TITLE
Update requirements.txt on docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ container-esl_scorematrix-push:
 .PHONY: docs
 docs:
 	${DOCS_CMD} ${DOCS_OPTS}
+	${RUN_CMD} pip freeze > requirements.txt
 	cd docs && make html
 
 .PHONY: docs-serve


### PR DESCRIPTION
ReadTheDocs uses a requirements.txt file. We can go ahead and just build that whenever we build the docs so that it stays updated.