### PR TITLE
Update converters to take output filenames

### DIFF
--- a/polyA/_app.py
+++ b/polyA/_app.py
@@ -77,16 +77,12 @@ def run():
     if opts.cm_to_stockholm:
         from .converters.cm_to_stockholm import convert
 
-        convert(
-            opts.cm_to_stockholm, opts.stockholm_filename, opts.matrix_filename
-        )
+        convert(opts.cm_to_stockholm, opts.stockholm_path, opts.matrix_path)
 
     if opts.rm_to_stockholm:
         from .converters.rm_to_stockholm import convert
 
-        convert(
-            opts.rm_to_stockholm, opts.stockholm_filename, opts.matrix_filename
-        )
+        convert(opts.rm_to_stockholm, opts.stockholm_path, opts.matrix_path)
 
     if opts.cm_to_stockholm or opts.rm_to_stockholm:
         if not (opts.alignments_file_path and opts.sub_matrices_path):

--- a/polyA/_app.py
+++ b/polyA/_app.py
@@ -77,12 +77,12 @@ def run():
     if opts.cm_to_stockholm:
         from .converters.cm_to_stockholm import convert
 
-        convert(opts.cm_to_stockholm)
+        convert(opts.cm_to_stockholm, opts.stockholm_filename, opts.matrix_filename)
 
     if opts.rm_to_stockholm:
         from .converters.rm_to_stockholm import convert
 
-        convert(opts.rm_to_stockholm)
+        convert(opts.rm_to_stockholm, opts.stockholm_filename, opts.matrix_filename)
 
     if opts.cm_to_stockholm or opts.rm_to_stockholm:
         if not (opts.alignments_file_path and opts.sub_matrices_path):

--- a/polyA/_app.py
+++ b/polyA/_app.py
@@ -77,12 +77,16 @@ def run():
     if opts.cm_to_stockholm:
         from .converters.cm_to_stockholm import convert
 
-        convert(opts.cm_to_stockholm, opts.stockholm_filename, opts.matrix_filename)
+        convert(
+            opts.cm_to_stockholm, opts.stockholm_filename, opts.matrix_filename
+        )
 
     if opts.rm_to_stockholm:
         from .converters.rm_to_stockholm import convert
 
-        convert(opts.rm_to_stockholm, opts.stockholm_filename, opts.matrix_filename)
+        convert(
+            opts.rm_to_stockholm, opts.stockholm_filename, opts.matrix_filename
+        )
 
     if opts.cm_to_stockholm or opts.rm_to_stockholm:
         if not (opts.alignments_file_path and opts.sub_matrices_path):

--- a/polyA/_options.py
+++ b/polyA/_options.py
@@ -263,8 +263,8 @@ class Options:
 
         self.cm_to_stockholm = namespace.cm_to_stockholm
         self.rm_to_stockholm = namespace.rm_to_stockholm
-        self.stockholm_path = namespace.stockholm_filename
-        self.matrix_path = namespace.matrix_filename
+        self.stockholm_path = namespace.stockholm_path
+        self.matrix_path = namespace.matrix_path
 
         if not (self.cm_to_stockholm or self.rm_to_stockholm):
             if not (self.alignments_file_path and self.alignments_file_path):

--- a/polyA/_options.py
+++ b/polyA/_options.py
@@ -63,6 +63,8 @@ class Options:
 
     cm_to_stockholm: str
     rm_to_stockholm: str
+    stockholm_path: str
+    matrix_path: str
 
     def __init__(self, args: Optional[List[str]] = None) -> None:
         parser = ArgumentParser(
@@ -216,6 +218,18 @@ class Options:
             default="",
             help="convert a file in CrossMatch format to PolyA's Stockholm format",
         )
+        parser.add_argument(
+            "--stockholm-path",
+            metavar="FILE",
+            default="",
+            help="path to the Stockholm file to create (for converters)",
+        )
+        parser.add_argument(
+            "--matrix-path",
+            metavar="FILE",
+            default="",
+            help="path to the matrix file to create (for converters)",
+        )
 
         namespace: Namespace
         if args is None:
@@ -249,9 +263,11 @@ class Options:
 
         self.cm_to_stockholm = namespace.cm_to_stockholm
         self.rm_to_stockholm = namespace.rm_to_stockholm
+        self.stockholm_path = namespace.stockholm_filename
+        self.matrix_path = namespace.matrix_filename
 
         if not (self.cm_to_stockholm or self.rm_to_stockholm):
             if not (self.alignments_file_path and self.alignments_file_path):
                 parser.error(
-                    "ALIGNMENTS and MATRICES and required unless using a converter"
+                    "ALIGNMENTS and MATRICES are required unless using a converter"
                 )

--- a/polyA/_runners.py
+++ b/polyA/_runners.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from math import log
+import math
 from sys import stdout
 from typing import Dict, List, Optional, TextIO, Tuple
 
@@ -117,7 +117,7 @@ def _change_probs(
     seq_count: int, trans_penalty: int
 ) -> Tuple[float, float, float]:
     change_prob = 10 ** (-1 * trans_penalty)
-    change_prob_log = log(change_prob / (seq_count - 1))
+    change_prob_log = math.log(change_prob / (seq_count - 1))
 
     # jumping in and then out of the skip state counts as 1 jump
     change_prob_skip = change_prob_log / 2

--- a/polyA/collapse_matrices.py
+++ b/polyA/collapse_matrices.py
@@ -1,5 +1,5 @@
+import math
 from typing import Dict, List, Tuple, Set
-from math import inf, log
 
 from .matrices import (
     CollapsedMatrices,
@@ -38,8 +38,8 @@ def dp_for_collapse(
     >>> p
     [2, 2, 2]
     """
-    change: float = log(0.000000001)
-    stay: float = log(1 - change)
+    change: float = math.log(0.000000001)
+    stay: float = math.log(1 - change)
 
     path: List[int] = []
 
@@ -64,9 +64,9 @@ def dp_for_collapse(
         for row0 in active[curr_col]:
             row = map_rows[row0]
 
-            max_value: float = -inf
+            max_value: float = -math.inf
             max_index: int = -1
-            support_log: float = log(support_matrix[row0, curr_col])
+            support_log: float = math.log(support_matrix[row0, curr_col])
 
             for row1 in active[prev_col]:
                 prev_row = map_rows[row1]
@@ -87,7 +87,7 @@ def dp_for_collapse(
 
     # get path from origin matrix
     # which row to start backtrace
-    max_value = -inf
+    max_value = -math.inf
     max_row_index = 0
     for i in active[non_empty[-1]]:
         if max_value < dp[i, non_empty[-1]]:

--- a/polyA/converters/cm_to_stockholm.py
+++ b/polyA/converters/cm_to_stockholm.py
@@ -196,13 +196,15 @@ def print_score_matrix(
     f_out_matrix.close()
 
 
-def convert(filename_cm: str):
+def convert(filename_cm: str, filename_out_sto: str, filename_out_matrix: str):
     file_contents = read_file(filename_cm)
 
-    filename_out_sto = filename_cm + ".sto"
+    if not filename_out_sto:
+        filename_out_sto = filename_cm + ".sto"
     f_out_sto = open(filename_out_sto, "w")
 
-    filename_out_matrix = filename_cm + ".matrix"
+    if not filename_out_matrix:
+        filename_out_matrix = filename_cm + ".matrix"
     matrix_name = "matrix1"
 
     f_out_sto.write("# STOCKHOLM 1.0\n")

--- a/polyA/converters/rm_to_stockholm.py
+++ b/polyA/converters/rm_to_stockholm.py
@@ -176,14 +176,16 @@ def print_score_matrix(f_out_matrix, score_matrix, matrix_name):
     f_out_matrix.write("//\n")
 
 
-def convert(filename_rm: str):
+def convert(filename_rm: str, filename_out_sto: str, filename_out_matrix: str):
     matrices = {}
     file_contents = read_file(filename_rm)
 
-    filename_out_sto = filename_rm + ".sto"
+    if not filename_out_sto:
+        filename_out_sto = filename_rm + ".sto"
     f_out_sto = open(filename_out_sto, "w")
 
-    filename_out_matrix = filename_rm + ".matrix"
+    if not filename_out_matrix:
+        filename_out_matrix = filename_rm + ".matrix"
     f_out_matrix = open(filename_out_matrix, "w")
 
     f_out_sto.write("# STOCKHOLM 1.0\n")
@@ -210,7 +212,7 @@ def convert(filename_rm: str):
         ):  # do not put duplicate of matrices in output file
             matrices[matrix_name] = 0
             score_matrix = get_score_matrix(matrix_name)
-            print_score_matrix(filename_out_matrix, score_matrix, matrix_name)
+            print_score_matrix(f_out_matrix, score_matrix, matrix_name)
 
         m = re.match(r"(.+?)\n([\s\S]+)\n\nMatrix", region)
         if m:
@@ -259,3 +261,4 @@ def convert(filename_rm: str):
         print_alignment(chrom_seq, subfam_seq, chrom, subfam, f_out_sto)
 
     f_out_sto.close()
+    f_out_matrix.close()

--- a/polyA/fill_align_matrix.py
+++ b/polyA/fill_align_matrix.py
@@ -1,4 +1,4 @@
-from math import inf
+import math
 from typing import Dict, List, Tuple, Optional
 
 from .calculate_score import (
@@ -250,7 +250,7 @@ def fill_align_matrix(
                     num_nucls = temp_count2
 
                     if num_nucls <= half_chunk:
-                        align_score = -inf
+                        align_score = -math.inf
 
                 else:
                     # align_score from previous segment - prev chars score + next chars score
@@ -300,7 +300,7 @@ def fill_align_matrix(
                     align_score / num_nucls * chunk_size
                 )
 
-                if align_score == -inf:
+                if align_score == -math.inf:
                     del align_matrix[i, col_index]
                     break
                 col_index += 1

--- a/polyA/fill_probability_matrix.py
+++ b/polyA/fill_probability_matrix.py
@@ -1,4 +1,4 @@
-from math import inf, log
+import math
 from typing import Dict, List, Tuple
 
 from polyA.matrices import CollapsedMatrices
@@ -78,9 +78,9 @@ def fill_probability_matrix(
         col_list.clear()
 
         for row_index in active_cells_collapse[curr_column]:
-            max_value: float = -inf
+            max_value: float = -math.inf
             max_index: int = 0
-            support_log: float = log(
+            support_log: float = math.log(
                 support_matrix_collapse[row_index, curr_column]
             )
             same_subfam_change: int = 0  # if 1 - comes from the same row, but gets change prob - add to same_subfam_change_matrix and use later in GetPath()

--- a/polyA/get_path.py
+++ b/polyA/get_path.py
@@ -1,4 +1,4 @@
-from math import inf
+import math
 from uuid import uuid4
 from typing import Dict, List, Tuple
 
@@ -64,7 +64,7 @@ def get_path(
     True
     """
 
-    maxxx: float = -inf
+    maxxx: float = -math.inf
     max_row_index: int = 0
 
     changes_position: List[int] = []


### PR DESCRIPTION
In order to allow the converters to be components within CyVerse, we need to be able to specify output filenames. This PR adds that capability but maintains the existing behavior as the default.