### PR TITLE
Fixed crash when --soda flag isn't set

### DIFF
--- a/polyA/_app.py
+++ b/polyA/_app.py
@@ -204,7 +204,7 @@ def run():
 
         
         soda_viz_file = (
-            outputter.get_soda(index) if opts.soda else (None, None)
+            outputter.get_soda(index) if opts.soda else None
         )
         printer.set_soda_files(soda_viz_file)
 

--- a/polyA/_version.py
+++ b/polyA/_version.py
@@ -1,4 +1,4 @@
-VERSION = "1.2.1"
+VERSION = "1.2.2"
 
 if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
The logic for the default file objects broke when I removed the now unused extra soda json output.